### PR TITLE
Set the ids in pasted features

### DIFF
--- a/shp_excel_sync.py
+++ b/shp_excel_sync.py
@@ -186,9 +186,10 @@ class Syncer(QObject):
         maxFk = self.get_max_id()
         for i, _ in enumerate(feats):
             _id = maxFk + i + 1
-            feats[i].setAttribute(self.shpKeyName, _id)
-
-        self.shpAdd = feats
+            new_feat = QgsFeature()
+            layer.getFeatures(QgsFeatureRequest(feats[i].id())).nextFeature(new_feat)
+            new_feat.setAttribute(self.shpKeyName, _id)
+            self.shpAdd.append(new_feat)
 
     def removed_geom_precommit(self, fids):
         #info("Removed fids"+str(fids))

--- a/shp_excel_sync.py
+++ b/shp_excel_sync.py
@@ -184,10 +184,8 @@ class Syncer(QObject):
         info("added feats " + str(feats))
         layer = layer_from_name(self.shpName)
         maxFk = self.get_max_id()
-        for i, _ in enumerate(feats):
+        for i, new_feat in enumerate(layer.getFeatures(QgsFeatureRequest().setFilterFids([f.id() for f in feats]))):
             _id = maxFk + i + 1
-            new_feat = QgsFeature()
-            layer.getFeatures(QgsFeatureRequest(feats[i].id())).nextFeature(new_feat)
             new_feat.setAttribute(self.shpKeyName, _id)
             self.shpAdd.append(new_feat)
 


### PR DESCRIPTION
Set the ids in the pasted features instead of in the copied, because otherwise we could have problems when the source layer does not have a valid id-field.

![shpsync-problem](https://user-images.githubusercontent.com/28384354/40066965-8ddc3efa-5865-11e8-8d31-0c10fbd19b89.gif)

With the signal `committedFeatureAdded` the `added_geom` slot in the plugin receives the copied features instead of the inserted ones. Means with fieldnames of the source layer instead the fieldnames of the destination layer.

This hasn't been a problem with copied features from a source-layer with a valid id-field. But in case it's different it was not possible to synchronize with the table.